### PR TITLE
fix issue #67

### DIFF
--- a/custom_components/ariston/water_heater.py
+++ b/custom_components/ariston/water_heater.py
@@ -3,10 +3,10 @@ import logging
 from datetime import timedelta
 
 from homeassistant.components.water_heater import (
-    SUPPORT_OPERATION_MODE,
-    SUPPORT_TARGET_TEMPERATURE,
     WaterHeaterEntity,
+    WaterHeaterEntityFeature
 )
+
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_NAME,
@@ -105,11 +105,11 @@ class AristonWaterHeater(WaterHeaterEntity):
         """Return the list of supported features."""
         try:
             if self._api.sensor_values[PARAM_DHW_MODE][OPTIONS_TXT]:
-                features = SUPPORT_TARGET_TEMPERATURE | SUPPORT_OPERATION_MODE
+                features = WaterHeaterEntityFeature.OPERATION_MODE | WaterHeaterEntityFeature.TARGET_TEMPERATURE
             else:
-                features = SUPPORT_TARGET_TEMPERATURE
+                features = WaterHeaterEntityFeature.TARGET_TEMPERATURE
         except KeyError:
-            return SUPPORT_TARGET_TEMPERATURE
+            return WaterHeaterEntityFeature.TARGET_TEMPERATURE
         return features
 
     @property


### PR DESCRIPTION
use [WaterHeaterEntityFeature](https://developers.home-assistant.io/docs/core/entity/water-heater#supported-features) instead of support constants as per [HA announcement](https://developers.home-assistant.io/blog/2022/04/02/support-constants-deprecation/)